### PR TITLE
generalize the type check in doexpect

### DIFF
--- a/src/clojure/expectations.clj
+++ b/src/clojure/expectations.clj
@@ -716,7 +716,7 @@
      (report (compare-expr e# a# '~e '~a))))
 
 (defmacro doexpect [e a]
-  (if (and (instance? clojure.lang.PersistentList e) (= 'interaction (first e)))
+  (if (and (list? e) (= 'interaction (first e)))
     `(do-interaction-expect ~e ~a)
     `(do-value-expect ~e ~a)))
 


### PR DESCRIPTION
`doexpect` checks for a `clojure.lang.PersistentList`, which is pretty much always going to be the case, but I think the `list?` predicate aligns better with the spirit of dynamism and golf.
