### PR TITLE
Typo fix in junit runner

### DIFF
--- a/src/clojure/expectations/junit/runner.clj
+++ b/src/clojure/expectations/junit/runner.clj
@@ -48,7 +48,7 @@
         _ (doseq [{:keys [absolutePath]} files] (load-file absolutePath))
         file-names (set (map :absolutePath files))
         suite-description (Description/createSuiteDescription (-> source class .getName) empty-ann-arr)
-        filtered-vars (->> (all-ns) (expectations/->expectations) (filter (partial in-loaded-file? file-names)))
+        filtered-vars (->> (all-ns) (expectations/->expectation) (filter (partial in-loaded-file? file-names)))
         descs (reduce create-desc {} filtered-vars)]
     (doseq [desc (vals descs)] (.addChild suite-description desc))
     (proxy [Runner] []


### PR DESCRIPTION
Fixed what looked like an apparent typo that made junit integration not work for me.
