### PR TITLE
Add numeral range to regex in test-file function

### DIFF
--- a/src/clojure/expectations.clj
+++ b/src/clojure/expectations.clj
@@ -98,7 +98,7 @@
   (str ns ":" line))
 
 (defn test-file [{:keys [file line]}]
-  (colorize-filename (str (last (re-seq #"[A-Za-z_\.]+" file)) ":" line)))
+  (colorize-filename (str (last (re-seq #"[0-9A-Za-z_\.]+" file)) ":" line)))
 
 (defn raw-str [[e a]]
   (with-out-str (clojure.pprint/pprint `(~'expect ~e ~a))))


### PR DESCRIPTION
Stumbled on this while trying to debug `lein autoexpect`, which has started hanging on file reload. I have a file/namespace which wraps some functionality related to Amazon's S3 service, and the existing regex was choking on the number in the file name. I suspect this is unrelated, but it'd be nice to fix in any case.

I tried to run the test suite for this library and it came up with 43 failures even without my change. Not sure if I'm doing something wrong, of if the tests are just out of date.