### PR TITLE
Make expectations usable again for ClojureScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Changes in version 2.1.1
+
+## ClojureScript support
+
+Make Expectations work with recent ClojureScript versions (> 0.0-2985). 
+
+Since [r2985](https://github.com/clojure/clojurescript/releases/tag/r2985) ClojureScript introduced macro symbols 
+in its analysis map, and Expectations tried to use them to construct vars, hence the failure described in 
+[a comment to #51](https://github.com/jaycfields/expectations/pull/51#issuecomment-83922145). This is now fixed.
+
 # Changes in version 2.1.0
 
 ## ClojureScript support

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :source-paths ["src/cljx" "src/clojure" "src/cljs"]
   :test-paths ["target/test-classes"]
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2913"]
+                 [org.clojure/clojurescript "0.0-2985"]
                  [joda-time/joda-time "2.7"]
                  [junit/junit "4.12"]]
 

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :source-paths ["src/cljx" "src/clojure" "src/cljs"]
   :test-paths ["target/test-classes"]
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2985"]
+                 [org.clojure/clojurescript "0.0-3196"]
                  [joda-time/joda-time "2.7"]
                  [junit/junit "4.12"]]
 

--- a/src/cljs/expectations/cljs.clj
+++ b/src/cljs/expectations/cljs.clj
@@ -6,6 +6,7 @@
   (assert (symbol? namespace) (str namespace))
   (assert (aapi/find-ns namespace) (str namespace))
   (->> (aapi/ns-interns namespace)
+    (filter (fn [[_ v]] (not (:macro v))))
     (map (fn [[k _]] `(var ~(symbol (name namespace) (name k)))))
     (into [])))
 

--- a/test/cljx/expectations/test.cljx
+++ b/test/cljx/expectations/test.cljx
@@ -1,7 +1,6 @@
 (ns expectations.test
   #+cljs (:require-macros [expectations.cljs :as ecljs])
-  (:require [expectations]
-            [success.expectations-options]
+  (:require [success.expectations-options]
             [success.success-examples]
             [success.nested.success-examples]))
 


### PR DESCRIPTION
Since [r2985](https://github.com/clojure/clojurescript/releases/tag/r2985) ClojureScript introduced macro symbols in its analysis map, and expectation tried to use them to construct vars, hence the failure described here: https://github.com/jaycfields/expectations/pull/51#issuecomment-83922145