### PR TITLE
fix for localizing the private state.

### DIFF
--- a/src/cljx/expectations.cljx
+++ b/src/cljx/expectations.cljx
@@ -587,7 +587,7 @@
   (when (p/bound? var)
     (when-let [vv @var]
       (when (p/iref-types (type vv))
-        [(var->symbol var) (list 'localize (var->symbol var))]))))
+        [(var->symbol var) (list 'localize `(deref ~var))]))))
 
 #+clj
 (defn- default-local-vals [namespaces]

--- a/test/cljx/success/success_examples.cljx
+++ b/test/cljx/success/success_examples.cljx
@@ -181,12 +181,26 @@
       (reset! success.success-examples-src/an-atom :atom)
       @success.success-examples-src/an-atom)))
 
+(expect :private-atom
+  (do
+    (reset! @#'success.success-examples-src/an-private-atom "private-atom")
+    (redef-state [success.success-examples-src]
+      (reset! @#'success.success-examples-src/an-private-atom :private-atom)
+      @@#'success.success-examples-src/an-private-atom)))
+
 (expect "atom"
   (do
     (reset! success.success-examples-src/an-atom "atom")
     (redef-state [success.success-examples-src]
       (reset! success.success-examples-src/an-atom :atom))
     @success.success-examples-src/an-atom))
+
+(expect "private-atom"
+  (do
+    (reset! @#'success.success-examples-src/an-private-atom "private-atom")
+    (redef-state [success.success-examples-src]
+      (reset! @#'success.success-examples-src/an-private-atom :private-atom))
+     @@#'success.success-examples-src/an-private-atom))
 
 ;; use expect-let to share a value between the actual and expected forms
 (expect-let [x 2]

--- a/test/cljx/success/success_examples_src.cljx
+++ b/test/cljx/success/success_examples_src.cljx
@@ -5,6 +5,8 @@
 
 (def an-atom (atom "atom"))
 
+(def ^:private an-private-atom (atom "private-atom"))
+
 (defn a-fn-to-be-rebound [])
 
 (defrecord ConstantlyTrue []

--- a/test/clojure/failure/failure_examples.clj
+++ b/test/clojure/failure/failure_examples.clj
@@ -82,12 +82,25 @@
                        (reset! success.success-examples-src/an-atom :something-else)
                        @success.success-examples-src/an-atom)))
 
+(expect :original
+        (with-redefs [success.success-examples-src/an-private-atom (atom :original)]
+          (redef-state [success.success-examples-src]
+            (reset! @#'success.success-examples-src/an-private-atom :something-else)
+            @@#'success.success-examples-src/an-private-atom)))
+
 (expect :atom
         (with-redefs [success.success-examples-src/an-atom (atom :original)]
           (do
             (redef-state [success.success-examples-src]
                          (reset! success.success-examples-src/an-atom :atom))
             @success.success-examples-src/an-atom)))
+
+(expect :atom
+        (with-redefs [success.success-examples-src/an-private-atom (atom :original)]
+          (do
+            (redef-state [success.success-examples-src]
+              (reset! @#'success.success-examples-src/an-private-atom :atom))
+            @@#'success.success-examples-src/an-private-atom)))
 
 (expect-let [x 2]
             4 x)


### PR DESCRIPTION
My English is poor, but I hope you can understand me.
——————
First, thank you for making a good testing framework.
When i using the `redef-state`, encountered a compile problem as following.
This problem is caused by an accessing the `private var`(e.g. `an-private-atom`).
So, I am trying to access the `private var` in the macro.

> Exception in thread "main" java.lang.IllegalStateException: var: success.success-examples-src/an-private-atom is not public, compiling:(success/success_examples.clj:180:5)

```clojure
(def ^:private an-private-atom (atom "private-atom"))
```

Thanks for reading.