### PR TITLE
Prioritize check for CustomPred in compare-expr

### DIFF
--- a/src/cljx/expectations.cljx
+++ b/src/cljx/expectations.cljx
@@ -322,6 +322,7 @@
 
 (defmulti compare-expr (fn [e a _ _]
                          (cond
+                           (satisfies? CustomPred e) ::custom-pred
                            (and (map? a) (not (sorted? a)) (contains? a ::from-each-flag)) ::from-each
                            (and (map? a) (not (sorted? a)) (contains? a ::in-flag)) ::in
                            (and (map? e) (not (sorted? e)) (contains? e ::more)) ::more
@@ -341,7 +342,6 @@
                            (and (instance? #+clj Class #+cljs js/Function e)
                                 (not (and (fn? e) (e a)))) ::expect-instance
                            (fn? e) ::fn
-                           (satisfies? CustomPred e) ::custom-pred
                            :default ::default)))
 
 (defmethod compare-expr ::equals [e a str-e str-a]


### PR DESCRIPTION
Move the `(satisfies? CustomPred e)` to the top of the cond check expression list in the `compare-expr` multimethod dispatch.

Seems reasonable to assume that if anyone's gone through the trouble of creating a custom predicate that they'd want that to take priority over any other heuristically determined expectation type. This was causing a bug where I had set up a new record type which satisfied CustomPred and was comparing it to a map. That configuration was triggering `(and (map? e) (map? a)) ::maps` at L330.

I ran the expectations test suite against this change, everything passed green. The only regressions I could imagine this causing downstream would be in cases where people set up custom predicates but were relying on the old behavior to *prevent* matching on the custom predicate. That seems... unlikely. :smile: