### PR TITLE
Fix expectations.expectations-expectations tests, add lein test aliases

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :jar-exclusions [#"\.swp|\.swo|\.DS_Store"]
   :java-source-paths ["src/java"]
   :source-paths ["src/cljc" "src/clojure" "src/cljs"]
-  :test-paths ["test/cljc" "test/clojure"]
+  :test-paths ["test/cljc" "test/clojure" "test"]
 
   :dependencies [[joda-time/joda-time "2.9.3"]
                  [junit/junit "4.12"]]
@@ -23,6 +23,8 @@
   :prep-tasks ["javac"]
   :auto-clean false
 
+  :aliases {"test" ["expectations" "expectations.*" "success.*"]
+            "test-fail" ["expectations" "failures.*"]}
 
   :cljsbuild {:builds [{:source-paths   ["src/cljs" "src/cljc" "test/cljs" "test/cljc"]
                         :notify-command ["node" "./target/out/test.js"]

--- a/test/expectations/expectations_expectations.clj
+++ b/test/expectations/expectations_expectations.clj
@@ -1,16 +1,26 @@
 (ns expectations.expectations-expectations
   (:use expectations))
 
-(expect "           result\n\n           expected-message\n           actual-message\n           message"
-        (->failure-message
-         {:raw "raw"
-          :result ["result"]
-          :expected-message "expected-message"
-          :actual-message "actual-message"
-          :message "message"}))
+(expect "           result
 
-(expect "(expect raw-e raw-a)\n\n           result
-\n           expected-message\n           actual-message\n           message"
+           expected-message
+           actual-message
+           message"
+        (with-redefs [show-raw-choice (constantly false)]
+          (->failure-message
+           {:raw "raw"
+            :result ["result"]
+            :expected-message "expected-message"
+            :actual-message "actual-message"
+            :message "message"
+            })))
+
+(expect "[36m(expect raw-e raw-a)\n[0m
+           result
+
+           expected-message
+           actual-message
+           message"
         (with-redefs [show-raw-choice (constantly true)]
           (->failure-message
            {:raw '(raw-e raw-a)
@@ -19,12 +29,23 @@
             :actual-message "actual-message"
             :message "message"})))
 
-(expect "(expect (whole thing) nil)\n
+(expect "[36m(expect (whole thing) nil)\n[0m
            the list blah
-\n(expect raw-e raw-a)\n\n           result\n\n           expected-message
-           actual-message\n           message
-\n(expect raw-e2 raw-a2)\n\n           result2\n\n           expected-message2
-           actual-message2\n           message2"
+
+[36m(expect raw-e raw-a)\n[0m
+           result
+
+           expected-message
+           actual-message
+           message
+
+[36m(expect raw-e2 raw-a2)\n[0m
+           result2
+
+           expected-message2
+           actual-message2
+           message2"
+
         (with-redefs [show-raw-choice (constantly true)]
           (->failure-message
            {:raw ['(whole thing)]
@@ -38,7 +59,9 @@
                     :result ["result2"]
                     :expected-message "expected-message2"
                     :actual-message "actual-message2"
-                    :message "message2"}]})))
+                    :message "message2"}]}))
+
+)
 
 (expect "           result
 \n           expected-message\n           actual-message\n           message"


### PR DESCRIPTION
The tests in test/expectations/expectations_expectations.clj were no longer up
to date, they ignored output colorization.

Added `lein test` and `lein test-fail` aliases to make it more obvious how to
run the test suite. The first command will run all tests that are supposed to
pass (currently 76), the second will run tests that check failing assertions,
and so are expected to fail.