### PR TITLE
Platform fixes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,8 +17,8 @@
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.clojure/clojurescript "1.8.34" :scope "provided"]]
                    :node-dependencies [[source-map-support "^0.2.9"]]
-                   :plugins           [[lein-cljsbuild "1.0.5"]
-                                       [lein-npm "0.5.0"]]}}
+                   :plugins           [[lein-cljsbuild "1.1.3"]
+                                       [lein-npm "0.6.2"]]}}
 
   :prep-tasks ["javac"]
   :auto-clean false


### PR DESCRIPTION
This fixes two issues: use in Clojure while the ClojureScript compiler is
loaded, and use in JavaScript outside Node.js.

Several macros use a helper function, `cljs?', to determine if the macro is
being used from a Clojure or ClojureScript context. The test would return false
positives. Turning it into a macro and inspecting the special variable `&env`
fixes that.

The ClojureScript output would assume a Node.js runtime, and thus access
node-only features like `process.hrtime' or `process.env'. Now it will check for
node and fall back to alternative implementations in other runtimes.

- environment variables are looked up as variables on `window' for fine-grained
  timing `performance.now()' is used, this means a relatively recent runtime is
- required detecting the OS is not implemented for non-Node ClojureScript
  runtimes, it is assumed it is not Windows.

To run tests against multiple runtimes you can use `doo' like so:

```clojure
(ns my-project.runner
  (:require-macros [expectations.cljs :refer [run-all-tests]])
  (:require [doo.runner :as doo]
            [my-project.namespace-with-tests]))

(doo/set-entry-point! (fn [] (run-all-tests)))
```

closes #54