### PR TITLE
Guard against NPE in regex expection

### DIFF
--- a/src/cljc/expectations.cljc
+++ b/src/cljc/expectations.cljc
@@ -460,7 +460,7 @@
   (compare-expr (str e) (str a) str-e str-a))
 
 (defmethod compare-expr ::re-seq [e a str-e str-a]
-  (if (re-seq e a)
+  (if (and a (re-seq e a))
     {:type :pass}
     {:type   :fail,
      :raw    [str-e str-a]


### PR DESCRIPTION
If you expect a regex of a string but your test fails such that the actual value is nil, you get an exception from the Java regex pattern matcher which obscures the actual test failure. This Pull Request guards the regex test so that a nil value will fail the test without an exception, making the test result much more useful.