### PR TITLE
Fix #80 by allowing predicates on exceptions

### DIFF
--- a/src/cljc/expectations.cljc
+++ b/src/cljc/expectations.cljc
@@ -445,10 +445,20 @@
      :expected-message (str "expected: " a " to be a " e)}))
 
 (defmethod compare-expr ::actual-exception [e a str-e str-a]
-  {:type           :error
-   :raw            [str-e str-a]
-   :actual-message (str "exception in actual: " str-a)
-   :result         [a]})
+  (let [error {:type           :error
+               :raw            [str-e str-a]
+               :actual-message (str "exception in actual: " str-a)
+               :result         [a]}]
+    (if (fn? e)
+      (try
+        (if (e a)
+          {:type :pass}
+          {:type :fail
+           :raw [str-e str-a]
+           :result ["exception thrown by" str-a "is not" str-e]})
+        (catch #?(:clj Throwable :cljs js/Error) _
+          error))
+      error)))
 
 (defmethod compare-expr ::expected-exception [e a str-e str-a]
   {:type             :error

--- a/test/cljc/success/success_examples.cljc
+++ b/test/cljc/success/success_examples.cljc
@@ -61,6 +61,10 @@
                       (comp (partial re-find #"Divide by zero")
                             (memfn getMessage)))
                 (/ 12 0)))
+#?(:clj (expect (more-of ex
+                         ArithmeticException ex
+                         "Divide by zero" (.getMessage ex))
+                (/ 12 0)))
 
 ;; verify the type of the result
 #?(:clj (expect String "foo")

--- a/test/cljc/success/success_examples.cljc
+++ b/test/cljc/success/success_examples.cljc
@@ -56,6 +56,12 @@
 ;; does the form throw an expeted exception
 #?(:clj (expect ArithmeticException (/ 12 0)))
 
+;; can we process an exception with predicates?
+#?(:clj (expect (more ArithmeticException
+                      (comp (partial re-find #"Divide by zero")
+                            (memfn getMessage)))
+                (/ 12 0)))
+
 ;; verify the type of the result
 #?(:clj (expect String "foo")
    :cljs (expect js/String "foo"))


### PR DESCRIPTION
This makes an expected predicate a special case for actual exceptions so
that you can expect more of an exception (than just its class).

The output from a predicate that fails on an exception is:

* The exception as the actual value (including stack trace)
* The message that "exception thrown by <actual expression> is not ..."

(showing the predicate that failed).

This seemed to be the best compromise after some experimentation.